### PR TITLE
Changed VUSBTiny link

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -10,7 +10,7 @@ The programmer was not developed by me, but with this repository I added to it i
 - designed a PCB for the project, in a way which should make it simple to be hand produced
 - wrote this readme, which can help you make your own VUSBtiny.
 
-You can find the original VUSBtiny page [here](https://simpleavr.github.io/old_projects/avr_vusbtiny/index.html).
+You can find the original VUSBtiny page [here](https://web.archive.org/web/20180423215321/http://www.simpleavr.com/avr/vusbtiny) (or [here](https://simpleavr.github.io/old_projects/avr_vusbtiny/index.html)).
 
 
 # License

--- a/Readme.md
+++ b/Readme.md
@@ -10,7 +10,7 @@ The programmer was not developed by me, but with this repository I added to it i
 - designed a PCB for the project, in a way which should make it simple to be hand produced
 - wrote this readme, which can help you make your own VUSBtiny.
 
-You can find the original VUSBtiny page [here](http://www.simpleavr.com/avr/vusbtiny).
+You can find the original VUSBtiny page [here](https://simpleavr.github.io/old_projects/avr_vusbtiny/index.html).
 
 
 # License


### PR DESCRIPTION
Link changed from "http://www.simpleavr.com/avr/vusbtiny" to "https://simpleavr.github.io/old_projects/avr_vusbtiny/index.html"

The original link is now not working and showing ads on a blank page. Maybe the domain wasn't renewed. I found this github pages site: https://simpleavr.github.io/ which has this notice at the top: "[July, 2018] creation of this launch page which should eventually host all of my published projects"

Seems legit but I've not seen the original simpleavr page so please check it out before merging.

Thanks for making this repo! 